### PR TITLE
History rates params to utc

### DIFF
--- a/product.go
+++ b/product.go
@@ -16,6 +16,7 @@ type Product struct {
 	BaseMinSize    float64 `json:"base_min_size,string"`
 	BaseMaxSize    float64 `json:"base_max_size,string"`
 	QuoteIncrement float64 `json:"quote_increment,string"`
+	DisplayName    string  `json:"display_name"`
 }
 
 type Ticker struct {

--- a/product.go
+++ b/product.go
@@ -16,7 +16,6 @@ type Product struct {
 	BaseMinSize    float64 `json:"base_min_size,string"`
 	BaseMaxSize    float64 `json:"base_max_size,string"`
 	QuoteIncrement float64 `json:"quote_increment,string"`
-	DisplayName    string  `json:"display_name"`
 }
 
 type Ticker struct {

--- a/product.go
+++ b/product.go
@@ -218,8 +218,8 @@ func (c *Client) GetHistoricRates(product string,
 	if !params.Start.IsZero() && !params.End.IsZero() && params.Granularity != 0 {
 		values := url.Values{}
 		layout := "2006-01-02T15:04:05Z"
-		values.Add("start", params.Start.Format(layout))
-		values.Add("end", params.End.Format(layout))
+		values.Add("start", params.Start.UTC().Format(layout))
+		values.Add("end", params.End.UTC().Format(layout))
 		values.Add("granularity", strconv.Itoa(params.Granularity))
 
 		requestURL = fmt.Sprintf("%s?%s", requestURL, values.Encode())


### PR DESCRIPTION
server expects time in utc, however format does not convert it

you could try a sample:
```javascript
package main

import(
	"time"
)

func main() {
    t := time.Unix(1445423641, 0)
    layout := "2006-01-02T15:04:05Z"
    res := t.Format(layout)	
    println(res)
}
```
its result depends on local timezone however it should not