### PR TITLE
Get full ticker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "go.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "go.formatOnSave": false
-}

--- a/product.go
+++ b/product.go
@@ -23,6 +23,9 @@ type Ticker struct {
 	Price   float64 `json:"price,string"`
 	Size    float64 `json:"size,string"`
 	Time    Time    `json:"time,string"`
+	Bid     float64 `json:"bid,string"`
+	Ask     float64 `json:"ask,string"`
+	Volume  float64 `json:"volume,string"`
 }
 
 type Trade struct {


### PR DESCRIPTION
Not sure why these fields were left out but I've added them as I needed them. The response is defined here: [https://docs.gdax.com/#get-product-ticker](url)