### PR TITLE
Added bid, ask, vol to ticker struct

### DIFF
--- a/product.go
+++ b/product.go
@@ -23,7 +23,11 @@ type Ticker struct {
 	Price   float64 `json:"price,string"`
 	Size    float64 `json:"size,string"`
 	Time    Time    `json:"time,string"`
+	Bid     float64 `json:"bid,string"`
+	Ask     float64 `json:"ask,string"`
+	Volume  float64 `json:"volume,string"`
 }
+
 
 type Trade struct {
 	TradeId int     `json:"trade_id,number"`


### PR DESCRIPTION
Not sure why these fields were left out but I've added them as I needed them. The response is defined here: https://docs.gdax.com/#get-product-ticker