### PR TITLE
Update Client base api url to GDAX

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ type Client struct {
 
 func NewClient(secret, key, passphrase string) *Client {
 	client := Client{
-		BaseURL:    "https://api.exchange.coinbase.com",
+		BaseURL:    "https://api.gdax.com",
 		Secret:     secret,
 		Key:        key,
 		Passphrase: passphrase,


### PR DESCRIPTION
As of August 24th, GDAX (formerly Coinbase Exchange) changed api endpoints to use the base URL "https://api.gdax.com"