### PR TITLE
Bug - Invalid API SSL Certs

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -79,7 +80,13 @@ func (c *Client) Request(method string, url string,
 	}
 	req.Header.Add("CB-ACCESS-SIGN", sig)
 
-	client := http.Client{}
+	httpClientTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	client := http.Client{Transport: httpClientTransport}
 	res, err = client.Do(req)
 	if err != nil {
 		return res, err


### PR DESCRIPTION
### Problem 

The SSL certificate for the GDAX API is invalid so a request to get historical rates throws an error.

```
panic: Get https://api.exchange.coinbase.com/products/ETH-BTC/candles?end=2017-05-16T01%3A44%3A25Z&granularity=300&start=2017-05-16T01%3A24%3A25Z: x509: certificate is valid for ssl566420.cloudflaressl.com, *.coinbase.com, coinbase.com, not api.exchange.coinbase.com
```

![image](https://cloud.githubusercontent.com/assets/2796074/26085101/843bedb0-39d9-11e7-9cd3-383be682f792.png)

### Solution

Allow for invalid SSL certificates until GDAX fixes it.

http://stackoverflow.com/a/12122718
