### PR TITLE
orders: Omit empty `size` field

### DIFF
--- a/order.go
+++ b/order.go
@@ -6,7 +6,7 @@ import (
 
 type Order struct {
 	Type      string  `json:"type"`
-	Size      float64 `json:"size,string"`
+	Size      float64 `json:"size,string,omitempty"`
 	Side      string  `json:"side"`
 	ProductId string  `json:"product_id"`
 	ClientOID string  `json:"client_oid,omitempty"`


### PR DESCRIPTION
For market orders, it is valid to omit `size` and only supply `funds`:
https://docs.gdax.com/#place-a-new-order

This is how market orders should be placed when, for instance, buying BTC using a fixed amount of USD (e.g. *buy $100 worth of BTC at market price*).

Size the `size` field was being serialized no matter what, the GDAX API was rejecting those requests with `size must be greater than zero (0)`.