### PR TITLE
Set Timeout element in http.Client{}

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func NewClient(secret, key, passphrase string) *Client {
 	return &client
 }
 
-func (c *Client) Request(method string, url string,
+func (c *Client) Request(method string, url string, client *http.Client,
 	params, result interface{}) (res *http.Response, err error) {
 	var data []byte
 	body := bytes.NewReader(make([]byte, 0))
@@ -79,7 +79,11 @@ func (c *Client) Request(method string, url string,
 	}
 	req.Header.Add("CB-ACCESS-SIGN", sig)
 
-	client := http.Client{}
+	if client == nil {
+		client = &http.Client{
+			Timeout: 15 * time.Second,
+		}
+	}
 	res, err = client.Do(req)
 	if err != nil {
 		return res, err


### PR DESCRIPTION
An `http.Client{}` will default to never timing out; in the event of a server hang the client will never finish without a `Timeout` set.

In order to provide the user with more granularity I've adjusted the `Request` function parameters to accept an `*http.Client` object. This allows users to set things like `net.Dialer.Timeout`, `http.Transport.TLSHandshakeTimeout`, `http.Transport.IdleConnTimeout`, etc... prior to passing an `*http.Client` to submit their request. In the event that `nil` is passed the function will define `client` with a `Timeout` of 15 seconds.

It is worth noting that this change will break apps using the previous definition of `Request`.